### PR TITLE
Improve the layout of the header

### DIFF
--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -1,4 +1,5 @@
 import { Form, NavLink, Outlet } from "@remix-run/react";
+import Grid from "@mui/material/Unstable_Grid2";
 
 import { useUser } from "~/utils";
 
@@ -9,17 +10,30 @@ export default function RestaurantsPage() {
 
   return (
     <div className="flex h-full min-h-screen flex-col">
-      <header className="flex items-center justify-between bg-sky-300 p-4 text-white">
-        <h1 className="text-3xl font-bold">Restaurants</h1>
-        <p>{user.email}</p>
-        <Form action="/logout" method="post">
-          <button
-            type="submit"
-            className="rounded bg-pink-400 py-2 px-4 text-blue-100 hover:bg-pink-600"
+      <header className="bg-sky-300 p-4 text-white">
+        <Grid container spacing={1}>
+          <Grid xs={12} className="text-center">
+            <h1 className="text-3xl font-bold">JK's Restaurants</h1>
+          </Grid>
+          <Grid
+            xs={12}
+            md={4}
+            mdOffset={2}
+            className="text-center md:text-left"
           >
-            Logout
-          </button>
-        </Form>
+            {user.email}
+          </Grid>
+          <Grid xs={12} md={4} className="text-center md:text-right">
+            <Form action="/logout" method="post">
+              <button
+                type="submit"
+                className="rounded bg-pink-500 py-2 px-4 text-blue-100 hover:bg-pink-600"
+              >
+                Logout
+              </button>
+            </Form>
+          </Grid>
+        </Grid>
       </header>
       <main className="h-full grid-cols-4 bg-gray-100 sm:grid">
         <div className="col-span-1 border-r border-black">


### PR DESCRIPTION
On Kylie's phone the logout button was pushed to the side which caused her to have to scroll sideways. Tailwind CSS has their own version of a grid but it is more confusing than it needs to be so instead of having to install reactstrap and potentially have SSR styling issues again, I found MUI had a grid system similar to bootstrap so I used theirs.