### PR TITLE
Revert "Trying something allow my fly deployments to work"

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -6,12 +6,5 @@
 # Learn more: https://community.fly.io/t/sqlite-not-getting-setup-properly/4386
 
 set -ex
-fallocate -l 256M /swapfile
-chmod 0600 /swapfile
-mkswap /swapfile
-echo 10 > /proc/sys/vm/swappiness
-swapon /swapfile
 npx prisma migrate deploy
-swapoff /swapfile
-rm /swapfile
 npm run start


### PR DESCRIPTION
This reverts commit 3873f6b753bde4f68d6b91b201e37c7f3ceb8c80.

I used to have an OOM error when trying to run migrations so I added this and it fixed it. Now I seem to get an error with swapfile but the migrations seem to have successfully run so I will go ahead and remove this for now. I dont think I will be making DB changes for a while so this should be ok but if I do, this might need to be readded? Fly error logs:
![image](https://github.com/user-attachments/assets/918465d5-191e-4ef7-a61c-ae87da8d1206)
