### PR TITLE
Remove `npx prisma migrate deploy` from start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -6,5 +6,18 @@
 # Learn more: https://community.fly.io/t/sqlite-not-getting-setup-properly/4386
 
 set -ex
-npx prisma migrate deploy
+# For future Josh that wants to make DB changes.
+# Uncomment the line below and include in the PR that gets merged
+# and goes through the deploy process. Before merging, go to your
+# local terminal and run these commands:
+# > flyctl image show
+# The above ^ command will output the machine id you need for the next command:
+# > flyctl machine update <machine_id> --vm-memory 512
+# After that gets deployed, then merge the PR and let the code deploy
+# and run the migrations. After that, comment the line below again and
+# merge and let that deploy. Then go to your local terminal and downsize the
+# memory back to 256:
+# > flyctl machine update <machine_id> --vm-memory 256
+# It sucks but such is life.
+# npx prisma migrate deploy
 npm run start


### PR DESCRIPTION
The comment in the code should explain the reasoning.

I should add that I believe the migrations have already been run since previous release I have seen the logs that there are no pending migrations to apply. So I think until I add more migrations, this command isn't needed