### PR TITLE
Revert "chore: allow prisma migrate deploy"

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -19,5 +19,5 @@ set -ex
 # memory back to 256:
 # > flyctl machine update <machine_id> --vm-memory 256
 # It sucks but such is life.
-npx prisma migrate deploy
+# npx prisma migrate deploy
 npm run start


### PR DESCRIPTION
This reverts commit d34e84e3230fdbd87c3dd13a6353c36ceb5fe183.