### PR TITLE
Use prisma@5.5.2 in the start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -19,5 +19,5 @@ set -ex
 # memory back to 256:
 # > flyctl machine update <machine_id> --vm-memory 256
 # It sucks but such is life.
-npx prisma migrate deploy
+npx prisma@5.5.2 migrate deploy
 npm run start


### PR DESCRIPTION
The latest error is when the start script is running and it tries to use prisma v6 which requires node 18 but the machine is using node 16. I will try this first since I think v5 works with node 16 which was what I started with.