### PR TITLE
Allow the machine memory to run at 256

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -19,5 +19,5 @@ set -ex
 # memory back to 256:
 # > flyctl machine update <machine_id> --vm-memory 256
 # It sucks but such is life.
-npx prisma@5.5.2 migrate deploy
+# npx prisma@5.5.2 migrate deploy
 npm run start


### PR DESCRIPTION
The prisma migration makes it run out of memory so we only migrate when necessary.