### PR TITLE
Quit using toISOString

### DIFF
--- a/app/components/CalendarDate.tsx
+++ b/app/components/CalendarDate.tsx
@@ -1,25 +1,33 @@
 import { PickersDay } from "@mui/x-date-pickers";
 import { Badge } from "@mui/joy";
+
+import { getDateStringWithoutTimezone } from "~/utils";
+
 import type { Dayjs } from "dayjs";
-
-import { formatDate } from "~/utils";
-
 import type { PickersDayProps } from "@mui/x-date-pickers";
 
 export default function CalendarDate(
   props: PickersDayProps<Dayjs> & {
     accomplishedDays?: string[];
-    startDate?: Dayjs;
+    startDate?: Date;
   }
 ) {
   const { accomplishedDays = [], day, startDate, ...other } = props;
 
   let badgeContent: string | number = 0;
   let badgeColor: "neutral" | "success" | "primary" = "neutral";
-  const isAccomplished = accomplishedDays.indexOf(formatDate(day)) >= 0;
-  const isStart = day.isSame(startDate, "day");
-  const endDate = startDate?.add(74, "day");
-  const isEnd = day.isSame(endDate, "day");
+  let isStart = false;
+  let isEnd = false;
+  const dateStringWithoutTimezone = getDateStringWithoutTimezone(day.toDate());
+  const isAccomplished =
+    accomplishedDays.indexOf(dateStringWithoutTimezone) >= 0;
+  if (startDate) {
+    isStart =
+      getDateStringWithoutTimezone(startDate) === dateStringWithoutTimezone;
+    const endDate = new Date(startDate);
+    endDate.setDate(endDate.getDate() + 74);
+    isEnd = getDateStringWithoutTimezone(endDate) === dateStringWithoutTimezone;
+  }
 
   if (isAccomplished) {
     badgeContent = "✅";

--- a/app/routes/seventy_five_hard/daily.tsx
+++ b/app/routes/seventy_five_hard/daily.tsx
@@ -3,7 +3,6 @@ import { Form, useActionData, useLoaderData } from "@remix-run/react";
 import { Button, Sheet } from "@mui/joy";
 import Alert from "@mui/joy/Alert";
 import { Switch, TextField } from "@mui/material";
-import dayjs from "dayjs";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleCheck } from "@fortawesome/free-solid-svg-icons";
 
@@ -16,6 +15,7 @@ import {
 import type { ActionArgs, LoaderArgs } from "@remix-run/node";
 import type { SeventyFiveHardDailyEntry } from "@prisma/client";
 import { ClientOnly } from "remix-utils";
+import { getDateStringWithoutTimezone } from "~/utils";
 
 export async function loader({ request }: LoaderArgs) {
   const userId = await requireUserId(request);
@@ -48,7 +48,8 @@ export default function Daily() {
   const actionData = useActionData();
   const entry = challenge.dailyEntries.find(
     (entry: SeventyFiveHardDailyEntry) =>
-      dayjs(entry.date).isSame(dayjs(), "day")
+      getDateStringWithoutTimezone(new Date(entry.date)) ===
+      getDateStringWithoutTimezone(new Date())
   );
 
   // TODO: either add a message or redirect if they go to this route and the current date is not in the challenge
@@ -76,7 +77,11 @@ export default function Daily() {
           <Form method="post">
             <input type="hidden" name="entryId" value={entry?.id} />
             <input type="hidden" name="challengeId" value={challenge.id} />
-            <input type="hidden" name="date" value={dayjs().toISOString()} />
+            <input
+              type="hidden"
+              name="date"
+              value={new Date().toDateString()}
+            />
             <label className="my-3 flex grid grid-cols-2 items-center justify-items-start gap-1">
               <span>Weight:</span>
               <TextField name="weight" defaultValue={entry?.weight} />

--- a/app/routes/seventy_five_hard/index.tsx
+++ b/app/routes/seventy_five_hard/index.tsx
@@ -5,7 +5,6 @@ import { ClientOnly } from "remix-utils";
 import { Button, Sheet, Typography } from "@mui/joy";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { DateCalendar, DayCalendarSkeleton } from "@mui/x-date-pickers";
-import dayjs from "dayjs";
 
 import CalendarDate from "~/components/CalendarDate";
 import { requireUserId } from "~/session.server";
@@ -15,9 +14,8 @@ import {
 } from "~/models/seventyFiveHard";
 
 import type { ActionArgs, LoaderArgs } from "@remix-run/node";
-import type { Dayjs } from "dayjs";
 import type { SeventyFiveHardDailyEntry } from "@prisma/client";
-import { formatDate } from "~/utils";
+import { getDateStringWithoutTimezone } from "~/utils";
 
 export async function loader({ request }: LoaderArgs) {
   const userId = await requireUserId(request);
@@ -37,7 +35,7 @@ export async function action({ request }: ActionArgs) {
 
 export default function Index() {
   const { challenge } = useLoaderData();
-  const [startDate, setStartDate] = useState<Dayjs | null>(dayjs());
+  const [startDate, setStartDate] = useState<Date | null>(new Date());
   if (!challenge) {
     return (
       <Sheet
@@ -59,7 +57,7 @@ export default function Index() {
             <input
               className="hidden"
               name="startDate"
-              value={startDate?.toISOString()}
+              value={startDate?.toDateString()}
               onChange={() => ""}
             />
             <Button type="submit" color="success" size="lg" className="block">
@@ -74,7 +72,6 @@ export default function Index() {
   const accomplishedDays: SeventyFiveHardDailyEntry[] =
     challenge.dailyEntries.filter(
       (entry: SeventyFiveHardDailyEntry, index: number) => {
-        console.log("josh001", index, entry);
         return (
           Boolean(entry.weight) &&
           entry.drankWater &&
@@ -86,7 +83,6 @@ export default function Index() {
         );
       }
     );
-  console.log("josh002", dayjs().toISOString());
   return (
     <ClientOnly>
       {() => (
@@ -99,10 +95,10 @@ export default function Index() {
           }}
           slotProps={{
             day: {
-              startDate: dayjs(challenge.startDate),
+              startDate: new Date(challenge.startDate),
               accomplishedDays: accomplishedDays.map(
                 (entry: SeventyFiveHardDailyEntry) =>
-                  formatDate(dayjs(entry.date))
+                  getDateStringWithoutTimezone(new Date(entry.date))
               ),
             } as any,
           }}

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -3,7 +3,6 @@ import { useMemo } from "react";
 import type { Prisma } from "@prisma/client";
 
 import type { User } from "~/models/user.server";
-import type { Dayjs } from "dayjs";
 
 const DEFAULT_REDIRECT = "/";
 
@@ -102,6 +101,7 @@ export function makeOptions(
   };
 }
 
-export function formatDate(date: Dayjs) {
-  return date.format("YYYY-MM-DD");
+export function getDateStringWithoutTimezone(date: Date): string {
+  const isoString = date.toISOString();
+  return isoString.slice(0, isoString.indexOf("T"));
 }


### PR DESCRIPTION
ISOString always sets the timezone to UTC which interferes when trying to compare dates. Regardless, it appears all of the data in the DB has timezone denotions. Thus I created a utility to convert to a string and strip out all aspects of time. I should have made the data structure to be just Dates since time is irrelevant for this feature but this will do for now.