### PR TITLE
Fully remove toISOString usage from 75 hard

### DIFF
--- a/app/components/CalendarDate.tsx
+++ b/app/components/CalendarDate.tsx
@@ -1,8 +1,6 @@
 import { PickersDay } from "@mui/x-date-pickers";
 import { Badge } from "@mui/joy";
 
-import { getDateStringWithoutTimezone } from "~/utils";
-
 import type { Dayjs } from "dayjs";
 import type { PickersDayProps } from "@mui/x-date-pickers";
 
@@ -18,15 +16,14 @@ export default function CalendarDate(
   let badgeColor: "neutral" | "success" | "primary" = "neutral";
   let isStart = false;
   let isEnd = false;
-  const dateStringWithoutTimezone = getDateStringWithoutTimezone(day.toDate());
+  const dateStringWithoutTimezone = day.toDate().toDateString();
   const isAccomplished =
     accomplishedDays.indexOf(dateStringWithoutTimezone) >= 0;
   if (startDate) {
-    isStart =
-      getDateStringWithoutTimezone(startDate) === dateStringWithoutTimezone;
+    isStart = startDate.toDateString() === dateStringWithoutTimezone;
     const endDate = new Date(startDate);
     endDate.setDate(endDate.getDate() + 74);
-    isEnd = getDateStringWithoutTimezone(endDate) === dateStringWithoutTimezone;
+    isEnd = endDate.toDateString() === dateStringWithoutTimezone;
   }
 
   if (isAccomplished) {

--- a/app/routes/seventy_five_hard/daily.tsx
+++ b/app/routes/seventy_five_hard/daily.tsx
@@ -15,7 +15,6 @@ import {
 import type { ActionArgs, LoaderArgs } from "@remix-run/node";
 import type { SeventyFiveHardDailyEntry } from "@prisma/client";
 import { ClientOnly } from "remix-utils";
-import { getDateStringWithoutTimezone } from "~/utils";
 
 export async function loader({ request }: LoaderArgs) {
   const userId = await requireUserId(request);
@@ -48,8 +47,7 @@ export default function Daily() {
   const actionData = useActionData();
   const entry = challenge.dailyEntries.find(
     (entry: SeventyFiveHardDailyEntry) =>
-      getDateStringWithoutTimezone(new Date(entry.date)) ===
-      getDateStringWithoutTimezone(new Date())
+      new Date(entry.date).toDateString() === new Date().toDateString()
   );
 
   // TODO: either add a message or redirect if they go to this route and the current date is not in the challenge

--- a/app/routes/seventy_five_hard/index.tsx
+++ b/app/routes/seventy_five_hard/index.tsx
@@ -15,7 +15,6 @@ import {
 
 import type { ActionArgs, LoaderArgs } from "@remix-run/node";
 import type { SeventyFiveHardDailyEntry } from "@prisma/client";
-import { getDateStringWithoutTimezone } from "~/utils";
 
 export async function loader({ request }: LoaderArgs) {
   const userId = await requireUserId(request);
@@ -98,7 +97,7 @@ export default function Index() {
               startDate: new Date(challenge.startDate),
               accomplishedDays: accomplishedDays.map(
                 (entry: SeventyFiveHardDailyEntry) =>
-                  getDateStringWithoutTimezone(new Date(entry.date))
+                  new Date(entry.date).toDateString()
               ),
             } as any,
           }}

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -100,8 +100,3 @@ export function makeOptions(
     return { label: obj.name, value, obj: obj };
   };
 }
-
-export function getDateStringWithoutTimezone(date: Date): string {
-  const isoString = date.toISOString();
-  return isoString.slice(0, isoString.indexOf("T"));
-}


### PR DESCRIPTION
Despite what the last PR claimed to do, 75 hard was still using `toISOString()` which caused the daily page to not show the check marks if we were on it late at night. Using `toDateString()` returns in the format "Thu Jan 23 2025" which normally isn't my go-to for date comparison but since I'm using it everywhere it should be consistent.