### PR TITLE
Change each date to be a route

### DIFF
--- a/app/routes/seventy_five_hard.tsx
+++ b/app/routes/seventy_five_hard.tsx
@@ -3,9 +3,11 @@ import Grid from "@mui/material/Unstable_Grid2"; // TODO: Update mui to v6 and c
 import { CreateOutlined, GridOn } from "@mui/icons-material";
 
 import { useUser } from "~/utils";
+import dayjs from "dayjs";
 
 export default function Index() {
   const user = useUser();
+  const today = dayjs(new Date()).format("MM-DD-YYYY");
 
   return (
     <div className="flex h-full min-h-screen flex-col">
@@ -52,7 +54,7 @@ export default function Index() {
           Progress
         </NavLink>
         <NavLink
-          to="/seventy_five_hard/daily"
+          to={`/seventy_five_hard/${today}`}
           className={({ isActive }) =>
             `ms-3 justify-self-start border-b p-4 text-xl hover:bg-sky-100 ${
               isActive

--- a/app/routes/seventy_five_hard/$date.tsx
+++ b/app/routes/seventy_five_hard/$date.tsx
@@ -1,6 +1,11 @@
 import { json } from "@remix-run/node";
-import { Form, useActionData, useLoaderData } from "@remix-run/react";
-import { useEffect, useState } from "react";
+import {
+  Form,
+  useActionData,
+  useLoaderData,
+  useNavigate,
+  useParams,
+} from "@remix-run/react";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import dayjs from "dayjs";
 import { Button, Sheet } from "@mui/joy";
@@ -17,7 +22,7 @@ import {
 
 import type { ActionArgs, LoaderArgs } from "@remix-run/node";
 import type { SeventyFiveHardDailyEntry } from "@prisma/client";
-import type { Dayjs } from "dayjs";
+import { useEffect, useState } from "react";
 
 export async function loader({ request }: LoaderArgs) {
   const userId = await requireUserId(request);
@@ -48,7 +53,9 @@ export async function action({ request }: ActionArgs) {
 export default function Daily() {
   const { challenge } = useLoaderData();
   const actionData = useActionData();
-  const [date, setDate] = useState<Dayjs | null>(dayjs());
+  const param = useParams();
+  const navigate = useNavigate();
+  const date = dayjs(new Date(param.date || ""));
   const entry = challenge.dailyEntries.find(
     (entry: SeventyFiveHardDailyEntry) =>
       dayjs(new Date(entry.date)).isSame(date, "day")
@@ -70,13 +77,13 @@ export default function Daily() {
   const [imageTaken, setImageTaken] = useState(entry?.imageTaken ?? false);
   useEffect(() => {
     if (entry) {
-      setWeight(entry.weight);
-      setDrankWater(entry.drankWater);
-      setIndoorWorkout(entry.indoorWorkout);
-      setOutdoorWorkout(entry.outdoorWorkout);
-      setReadTenPages(entry.readTenPages);
-      setFollowedDiet(entry.followedDiet);
-      setImageTaken(entry.imageTaken);
+      setWeight(entry.weight || "");
+      setDrankWater(entry.drankWater || false);
+      setIndoorWorkout(entry.indoorWorkout || false);
+      setOutdoorWorkout(entry.outdoorWorkout || false);
+      setReadTenPages(entry.readTenPages || false);
+      setFollowedDiet(entry.followedDiet || false);
+      setImageTaken(entry.imageTaken || false);
     } else {
       setWeight("");
       setDrankWater(false);
@@ -107,14 +114,20 @@ export default function Daily() {
         </Alert>
       )}
       <Form method="post">
-        <input type="hidden" name="entryId" value={entry?.id} />
+        <input type="hidden" name="entryId" value={entry?.id || ""} />
         <input type="hidden" name="challengeId" value={challenge.id} />
         <DatePicker
           className="my-3"
           value={date}
-          onChange={(newValue) => setDate(newValue)}
+          onChange={(newValue) =>
+            navigate(`../${newValue?.format("MM-DD-YYYY") || ""}`)
+          }
         />
-        <input type="hidden" name="date" value={date?.format("MM/DD/YYYY")} />
+        <input
+          type="hidden"
+          name="date"
+          value={new Date(date?.format("MM/DD/YYYY")).toString()}
+        />
         <label className="my-3 flex grid grid-cols-2 items-center justify-items-start gap-1">
           <span>Weight:</span>
           <TextField


### PR DESCRIPTION
That is mostly so if the user refreshes, it won't change the date on them. The biggest fix is to go ahead and send the full datetime to the server including timezone. Before when I was only sending MM/DD/YYYY, the server would be able to apply its own timezone. But if the client sends its timezone, then the server has to use that. Dayjs needs an extension to use timezones so I figured it would be simpler to convert from dayjs -> Date -> to string with timezone since the built in JS Date object automatically uses timezone.

I also cleaned up the console errors by not allowing the input value to ever be `undefined` by instead defaulting to empty string or false if there is no entry for a day. I think to clean the code up in the future would be to auto create an entry in the loader if it doesn't exist then the frontend will always have an entry and not need to worry about defaults.

Also I think having controlled components is a must for remix due to however hydration works, it doesn't actually fully re-render components even when the date route changes.